### PR TITLE
Disable setup-gradle Enhanced Caching and delegate to setup-java

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,10 +13,13 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
+          cache: gradle
           distribution: temurin
           java-version: 21
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
+        with:
+          cache-disabled: true
       - name: Login to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:


### PR DESCRIPTION
## Summary

- Disable `setup-gradle` proprietary Enhanced Caching (`cache-disabled: true`) across all workflows
- Delegate caching to `setup-java` with `cache: gradle` (MIT-licensed, writes on all branches)

Tracked by [INT-247](https://linear.app/hivemq/issue/INT-247)