### PR TITLE
[LATEST] PLATFORM: Upgrade toolchain to Java 25

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,9 @@ jobs:
         with:
           cache: gradle
           distribution: temurin
-          java-version: 21
+          java-version: |
+            21
+            25
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
         with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,11 +32,27 @@ hivemqExtension {
     }
 }
 
+val mockitoAgent = configurations.create("mockitoAgent") {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+}
+dependencies {
+    mockitoAgent(libs.mockito) { isTransitive = false }
+}
+class MockitoAgentArgumentProvider(@get:Classpath val agentJar: FileCollection) : CommandLineArgumentProvider {
+    override fun asArguments(): Iterable<String> = listOf("-javaagent:${agentJar.singleFile}")
+}
+
 @Suppress("UnstableApiUsage")
 testing {
     suites {
         withType<JvmTestSuite> {
             useJUnitJupiter(libs.versions.junit.jupiter)
+            targets.configureEach {
+                testTask {
+                    jvmArgumentProviders.add(MockitoAgentArgumentProvider(mockitoAgent))
+                }
+            }
         }
         "test"(JvmTestSuite::class) {
             dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,8 @@ testing {
             targets.configureEach {
                 testTask {
                     jvmArgumentProviders.add(MockitoAgentArgumentProvider(mockitoAgent))
+                    // see https://netty.io/wiki/java-24-and-sun.misc.unsafe.html
+                    jvmArgs("--enable-native-access=ALL-UNNAMED", "--sun-misc-unsafe-memory-access=allow")
                 }
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,12 @@ description = "HiveMQ 4 Hello World Extension - a simple reference for all exten
 
 java {
     toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
+tasks.compileJava {
+    javaCompiler = javaToolchains.compilerFor {
         languageVersion = JavaLanguageVersion.of(21)
     }
 }


### PR DESCRIPTION
Upgrade the build toolchain to Java 25 and pin the compile target to Java 21 via a compilerFor override.

Part of INT-8.